### PR TITLE
fix: make webhook amount validation mandatory (closes #2)

### DIFF
--- a/includes/class-oen-webhook-handler.php
+++ b/includes/class-oen-webhook-handler.php
@@ -43,15 +43,20 @@ class OEN_Webhook_Handler {
             return;
         }
 
-        // Defense-in-depth: verify webhook amount matches order total.
-        $webhook_amount = $payload['amount'] ?? null;
-        $order_total    = intval( $order->get_total() );
-        if ( null !== $webhook_amount && intval( $webhook_amount ) !== $order_total ) {
+        // Verify webhook amount matches order total — amount is mandatory.
+        if ( ! isset( $payload['amount'] ) || ! ctype_digit( (string) $payload['amount'] ) ) {
+            $this->log( sprintf( 'Invalid or missing amount in webhook for order #%d', $order->get_id() ) );
+            wp_send_json( [ 'status' => 'error', 'message' => 'Invalid or missing amount' ], 400 );
+            return;
+        }
+
+        $order_total = intval( $order->get_total() );
+        if ( intval( $payload['amount'] ) !== $order_total ) {
             $this->log(
                 sprintf(
                     'Amount mismatch for order #%d: webhook=%s, order=%d',
                     $order->get_id(),
-                    $webhook_amount,
+                    $payload['amount'],
                     $order_total
                 )
             );


### PR DESCRIPTION
## Summary
- Make `amount` field mandatory in webhook payload — reject if missing or non-numeric
- Previously, omitting the `amount` key caused `$payload['amount'] ?? null` to be `null`, and `null !== null` evaluated to `false`, skipping the entire amount check
- Add `is_numeric()` guard to reject polluted values like `"100abc"` (which `intval()` silently truncates to `100`)

## Security Impact
- **Before**: Attacker could omit `amount` from webhook to bypass amount validation entirely
- **After**: Missing or non-numeric amount → HTTP 400 rejection

## Note
PR #7 (issue #1) provides deeper protection via server-side API verification. This PR is a focused, independently-mergeable fix for the amount bypass specifically.

## Test Plan
- [ ] Webhook without `amount` key → returns 400 "Missing amount"
- [ ] Webhook with `amount: "abc"` → returns 400 "Missing amount"
- [ ] Webhook with `amount: "100abc"` → returns 400 "Missing amount"
- [ ] Webhook with `amount: 500` matching order total → passes validation
- [ ] Webhook with `amount: 999` not matching order total → returns 400 "Amount mismatch"

Closes #2