### PR TITLE
fix: sanitize webhook payload fields to prevent HTML injection (closes #3)

### DIFF
--- a/includes/class-oen-webhook-handler.php
+++ b/includes/class-oen-webhook-handler.php
@@ -28,6 +28,13 @@ class OEN_Webhook_Handler {
             return;
         }
 
+        // Sanitize all external string fields to prevent HTML injection in
+        // order notes, meta values, and log entries.
+        $payload['orderId']        = sanitize_text_field( $payload['orderId'] );
+        $payload['transactionHid'] = sanitize_text_field( $payload['transactionHid'] ?? '' );
+        $payload['status']         = sanitize_text_field( $payload['status'] ?? '' );
+        $payload['message']        = sanitize_text_field( $payload['message'] ?? '' );
+
         $order = $this->find_order_by_oen_order_id( $payload['orderId'] );
 
         if ( ! $order ) {
@@ -118,7 +125,7 @@ class OEN_Webhook_Handler {
      * @param array     $payload The webhook payload.
      */
     private function handle_failure( \WC_Order $order, array $payload ): void {
-        $message = $payload['message'] ?? __( 'Payment failed.', 'woocommerce-oen-payment' );
+        $message = $payload['message'] ?: __( 'Payment failed.', 'woocommerce-oen-payment' );
 
         $order->update_status(
             'failed',


### PR DESCRIPTION
## Summary
- Sanitize `orderId`, `transactionHid`, `status`, `message` via `sanitize_text_field()` immediately after JSON decode
- Prevents HTML injection into admin order notes (`wp_kses_post` allows `<a>`, `<img>` tags)
- Prevents log injection with crafted strings
- `paymentInfo` sub-fields (cvsName, code, expiredAt) were already sanitized — no change needed

## Security Impact
- **Before**: Attacker could inject `<a href="https://evil.com">Click here</a>` via `message` field, displayed in admin order notes
- **After**: All HTML stripped by `sanitize_text_field()` before any use

## Test Plan
- [ ] Send webhook with `message: "<a href='evil.com'>Click</a>"` → order note shows plain text, no link
- [ ] Send webhook with `transactionHid: "<img src=x>"` → meta stored as plain text
- [ ] Normal webhook with clean data → processes unchanged
- [ ] Verify order notes in WooCommerce admin show no HTML rendering from webhook data

Closes #3