### PR TITLE
fix: add webhook transaction status mapping instead of treating all non-charged as failed

### DIFF
--- a/includes/class-oen-webhook-handler.php
+++ b/includes/class-oen-webhook-handler.php
@@ -91,10 +91,39 @@ class OEN_Webhook_Handler {
                 } else {
                     $status = $transaction['status'] ?? '';
 
-                    if ( 'charged' === $status ) {
-                        $this->handle_success( $order, $transaction );
-                    } else {
-                        $this->handle_failure( $order, $transaction );
+                    switch ( $status ) {
+                        case 'charged':
+                            $this->handle_success( $order, $transaction );
+                            break;
+
+                        case 'pending':
+                        case 'created':
+                            // 中間狀態 — 不改變訂單狀態，等待後續 webhook。
+                            $this->log( 'Order #' . $order->get_id() . ' transaction status: ' . $status . ', no action taken.' );
+                            break;
+
+                        case 'expired':
+                            $order->update_status(
+                                'cancelled',
+                                sprintf(
+                                    __( 'OEN transaction expired (status: %s).', 'woocommerce-oen-payment' ),
+                                    $status
+                                )
+                            );
+                            $this->log( 'Order #' . $order->get_id() . ' cancelled due to expired transaction.' );
+                            break;
+
+                        case 'refunded':
+                            $order->update_status(
+                                'refunded',
+                                __( 'OEN transaction refunded.', 'woocommerce-oen-payment' )
+                            );
+                            $this->log( 'Order #' . $order->get_id() . ' marked as refunded.' );
+                            break;
+
+                        default:
+                            $this->handle_failure( $order, $transaction );
+                            break;
                     }
                 }
             }

--- a/includes/class-oen-webhook-handler.php
+++ b/includes/class-oen-webhook-handler.php
@@ -103,6 +103,10 @@ class OEN_Webhook_Handler {
                             break;
 
                         case 'expired':
+                            if ( $order->has_status( [ 'processing', 'completed', 'refunded' ] ) ) {
+                                $this->log( 'Order #' . $order->get_id() . ' ignoring expired — already ' . $order->get_status() . '.' );
+                                break;
+                            }
                             $order->update_status(
                                 'cancelled',
                                 sprintf(


### PR DESCRIPTION
## Summary

- Closes #12
- 原本 webhook handler 只判斷 `charged` 為成功，其餘一律走 `handle_failure()` 標記為 failed，導致 `pending`、`created`、`expired`、`refunded` 等合法狀態被錯誤處理。
- 改為 switch-case 明確對應每種 transaction status：
  - `charged` → 成功
  - `pending` / `created` → 不動作，等待後續 webhook
  - `expired` → 取消訂單
  - `refunded` → 標記退款
  - 其餘未知狀態 → 走 failure 處理

## Test plan

- [ ] 發送 status=charged 的 webhook，確認訂單標記為成功
- [ ] 發送 status=pending 的 webhook，確認訂單狀態不變
- [ ] 發送 status=created 的 webhook，確認訂單狀態不變
- [ ] 發送 status=expired 的 webhook，確認訂單標記為 cancelled
- [ ] 發送 status=refunded 的 webhook，確認訂單標記為 refunded
- [ ] 發送未知 status 的 webhook，確認走 handle_failure 流程