### PR TITLE
feat: WooCommerce Blocks support + integration test suite (L1/L2/L3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ composer.lock
 # Environment
 .env
 .env.*
+
+# test evidence (screenshots/recordings/logs) — not committed
+tests/evidence/

--- a/assets/js/blocks-payment-method.js
+++ b/assets/js/blocks-payment-method.js
@@ -1,0 +1,40 @@
+( function () {
+    const { registerPaymentMethod } = window.wc.wcBlocksRegistry;
+    const { getPaymentMethodData } = window.wc.wcSettings;
+    const { decodeEntities } = window.wp.htmlEntities;
+    const { RawHTML, createElement } = window.wp.element;
+    const { sanitizeHTML } = window.wc.sanitize;
+
+    const registerOenPaymentMethod = ( name ) => {
+        const settings = getPaymentMethodData( name, null );
+
+        if ( ! settings ) {
+            return;
+        }
+
+        const title = decodeEntities( settings.title || '' );
+        const Description = () =>
+            createElement( RawHTML, {
+                children: sanitizeHTML( settings.description || '' ),
+            } );
+        const Label = ( props ) => {
+            const { PaymentMethodLabel } = props.components;
+            return createElement( PaymentMethodLabel, { text: title } );
+        };
+
+        registerPaymentMethod( {
+            name,
+            label: createElement( Label ),
+            content: createElement( Description ),
+            edit: createElement( Description ),
+            canMakePayment: () => true,
+            ariaLabel: title,
+            supports: {
+                features: settings.supports || [ 'products' ],
+            },
+        } );
+    };
+
+    registerOenPaymentMethod( 'oen_credit' );
+    registerOenPaymentMethod( 'oen_cvs' );
+} )();

--- a/includes/class-oen-blocks-payment-method.php
+++ b/includes/class-oen-blocks-payment-method.php
@@ -1,0 +1,63 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
+
+class OEN_Blocks_Payment_Method extends AbstractPaymentMethodType {
+
+    private string $gateway_class;
+
+    public function __construct( string $name, string $gateway_class ) {
+        $this->name          = $name;
+        $this->gateway_class = $gateway_class;
+    }
+
+    public function initialize(): void {
+        $this->settings = get_option( 'woocommerce_' . $this->name . '_settings', [] );
+    }
+
+    public function is_active(): bool {
+        if ( 'yes' !== get_option( 'oen_enabled', 'no' ) ) {
+            return false;
+        }
+
+        if ( empty( get_option( 'oen_merchant_id', '' ) ) || empty( get_option( 'oen_api_token', '' ) ) ) {
+            return false;
+        }
+
+        if ( 'yes' !== $this->get_setting( 'enabled', 'no' ) ) {
+            return false;
+        }
+
+        return class_exists( $this->gateway_class );
+    }
+
+    public function get_payment_method_script_handles(): array {
+        $handle = 'oen-blocks-payment-method';
+
+        wp_register_script(
+            $handle,
+            OEN_PAYMENT_PLUGIN_URL . 'assets/js/blocks-payment-method.js',
+            [
+                'wc-blocks-registry',
+                'wc-settings',
+                'wp-element',
+                'wp-html-entities',
+                'wc-sanitize',
+            ],
+            OEN_PAYMENT_VERSION,
+            true
+        );
+
+        return [ $handle ];
+    }
+
+    public function get_payment_method_data(): array {
+        return [
+            'title'       => $this->get_setting( 'title' ),
+            'description' => $this->get_setting( 'description' ),
+            'supports'    => $this->get_supported_features(),
+        ];
+    }
+}

--- a/includes/class-oen-blocks-payment-method.php
+++ b/includes/class-oen-blocks-payment-method.php
@@ -53,6 +53,11 @@ class OEN_Blocks_Payment_Method extends AbstractPaymentMethodType {
         return [ $handle ];
     }
 
+    public function get_payment_method_script_handles_for_admin(): array {
+        // Reuse the same registration so the method previews in the block editor.
+        return $this->get_payment_method_script_handles();
+    }
+
     public function get_payment_method_data(): array {
         return [
             'title'       => $this->get_setting( 'title' ),

--- a/tests/BlocksPaymentMethodTest.php
+++ b/tests/BlocksPaymentMethodTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Unit tests for the ported WooCommerce Blocks integration (OEN_Blocks_Payment_Method).
+ *
+ * is_active() gates whether OEN shows in the block checkout; it must mirror the
+ * classic gateway's is_available() (master toggle + credentials + per-gateway
+ * enable + gateway class present). Uses a stub of the Blocks base class so the
+ * plugin class can be instantiated without WooCommerce Blocks installed.
+ */
+
+namespace Automattic\WooCommerce\Blocks\Payments\Integrations {
+    if ( ! class_exists( __NAMESPACE__ . '\\AbstractPaymentMethodType', false ) ) {
+        abstract class AbstractPaymentMethodType {
+            protected $name     = '';
+            protected $settings = [];
+
+            public function get_setting( string $key, $default = '' ) {
+                return $this->settings[ $key ] ?? $default;
+            }
+
+            public function get_supported_features(): array {
+                return [ 'products' ];
+            }
+        }
+    }
+}
+
+namespace {
+    require_once __DIR__ . '/bootstrap.php';
+
+    if ( ! defined( 'OEN_PAYMENT_PLUGIN_URL' ) ) {
+        define( 'OEN_PAYMENT_PLUGIN_URL', 'https://store.example/wp-content/plugins/woocommerce-oen-payment/' );
+    }
+    if ( ! defined( 'OEN_PAYMENT_VERSION' ) ) {
+        define( 'OEN_PAYMENT_VERSION', 'test' );
+    }
+
+    if ( ! function_exists( 'wp_register_script' ) ) {
+        function wp_register_script( string $handle, string $src, array $deps = [], $ver = false, bool $in_footer = false ): bool {
+            $GLOBALS['test_registered_scripts'][ $handle ] = [ 'src' => $src, 'deps' => $deps, 'ver' => $ver ];
+            return true;
+        }
+    }
+
+    // Stub the concrete gateway class that is_active() probes via class_exists().
+    if ( ! class_exists( 'WC_Gateway_OEN_Credit', false ) ) {
+        class WC_Gateway_OEN_Credit {}
+    }
+
+    require_once __DIR__ . '/../includes/class-oen-blocks-payment-method.php';
+
+    function blk_reset( array $options = [] ): void {
+        $GLOBALS['test_options']            = $options;
+        $GLOBALS['test_registered_scripts'] = [];
+    }
+
+    function blk_active_options(): array {
+        return [
+            'oen_enabled'                     => 'yes',
+            'oen_merchant_id'                 => 'merchant-1',
+            'oen_api_token'                   => 'sk_test_x',
+            'woocommerce_oen_credit_settings' => [ 'enabled' => 'yes', 'title' => 'OEN Credit', 'description' => 'Pay by card' ],
+        ];
+    }
+
+    function blk_make( string $name = 'oen_credit', string $gateway = 'WC_Gateway_OEN_Credit' ): OEN_Blocks_Payment_Method {
+        $method = new OEN_Blocks_Payment_Method( $name, $gateway );
+        $method->initialize();
+        return $method;
+    }
+
+    function test_block_active_when_all_conditions_met(): void {
+        blk_reset( blk_active_options() );
+        test_assert( true === blk_make()->is_active(), 'Block method should be active when master + credentials + per-gateway enable + gateway class are all present.' );
+    }
+
+    function test_block_inactive_when_master_toggle_off(): void {
+        $options                = blk_active_options();
+        $options['oen_enabled'] = 'no';
+        blk_reset( $options );
+        test_assert( false === blk_make()->is_active(), 'Block method must be inactive when the master oen_enabled toggle is off.' );
+    }
+
+    function test_block_inactive_when_credentials_missing(): void {
+        $options                  = blk_active_options();
+        $options['oen_api_token'] = '';
+        blk_reset( $options );
+        test_assert( false === blk_make()->is_active(), 'Block method must be inactive when the secret key is missing.' );
+    }
+
+    function test_block_inactive_when_gateway_disabled(): void {
+        $options                                    = blk_active_options();
+        $options['woocommerce_oen_credit_settings'] = [ 'enabled' => 'no' ];
+        blk_reset( $options );
+        test_assert( false === blk_make()->is_active(), 'Block method must be inactive when the per-gateway enable is off.' );
+    }
+
+    function test_block_inactive_when_gateway_class_missing(): void {
+        $options                                   = blk_active_options();
+        $options['woocommerce_oen_ghost_settings'] = [ 'enabled' => 'yes' ];
+        blk_reset( $options );
+        test_assert( false === blk_make( 'oen_ghost', 'WC_Gateway_OEN_Nonexistent' )->is_active(), 'Block method must be inactive when its gateway class does not exist, even if otherwise enabled.' );
+    }
+
+    function test_block_payment_method_data_shape(): void {
+        blk_reset( blk_active_options() );
+        $data = blk_make()->get_payment_method_data();
+        test_assert( 'OEN Credit' === ( $data['title'] ?? null ), 'get_payment_method_data() title should come from the gateway settings.' );
+        test_assert( array_key_exists( 'description', $data ), 'get_payment_method_data() should include description.' );
+        test_assert( array_key_exists( 'supports', $data ), 'get_payment_method_data() should include supports (feature list).' );
+    }
+
+    function test_block_script_handle_registered_with_registry_dependency(): void {
+        blk_reset( blk_active_options() );
+        $handles = blk_make()->get_payment_method_script_handles();
+        test_assert( [ 'oen-blocks-payment-method' ] === $handles, 'get_payment_method_script_handles() should return the block script handle.' );
+        $registered = $GLOBALS['test_registered_scripts']['oen-blocks-payment-method'] ?? null;
+        test_assert( is_array( $registered ), 'The block payment method script should be registered.' );
+        test_assert( in_array( 'wc-blocks-registry', $registered['deps'], true ), 'The block script must depend on wc-blocks-registry.' );
+    }
+
+    test_block_active_when_all_conditions_met();
+    test_block_inactive_when_master_toggle_off();
+    test_block_inactive_when_credentials_missing();
+    test_block_inactive_when_gateway_disabled();
+    test_block_inactive_when_gateway_class_missing();
+    test_block_payment_method_data_shape();
+    test_block_script_handle_registered_with_registry_dependency();
+
+    echo "Blocks payment method harness passed.\n";
+}

--- a/tests/CheckoutParamsTest.php
+++ b/tests/CheckoutParamsTest.php
@@ -1,0 +1,296 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Locks the create-session request contract that the Hosted Checkout backend
+ * enforces but the existing harnesses do not cover:
+ *
+ *  - productDetails must reconcile to `amount` (Σ unitPrice×quantity === total),
+ *    otherwise the backend rejects the session with PRODUCT_AMOUNT_NOT_MATCH
+ *    (legacy code V0001). build_product_details() guarantees this with an ADJ line.
+ *  - allowedPaymentMethods must use the backend's exact enum strings
+ *    (`cvs`; card is the backend default and must be omitted, not sent as `card`).
+ */
+
+require_once __DIR__ . '/bootstrap.php';
+
+if ( ! defined( 'OEN_PAYMENT_PLUGIN_URL' ) ) {
+    define( 'OEN_PAYMENT_PLUGIN_URL', 'https://store.example/wp-content/plugins/woocommerce-oen-payment/' );
+}
+if ( ! defined( 'OEN_PAYMENT_VERSION' ) ) {
+    define( 'OEN_PAYMENT_VERSION', 'test' );
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+    function add_action( string $hook, array $callback ): void {}
+}
+if ( ! function_exists( 'wc_get_checkout_url' ) ) {
+    function wc_get_checkout_url(): string {
+        return 'https://store.example/checkout';
+    }
+}
+if ( ! function_exists( 'wc_get_cart_url' ) ) {
+    function wc_get_cart_url(): string {
+        return 'https://store.example/cart';
+    }
+}
+if ( ! function_exists( 'get_bloginfo' ) ) {
+    function get_bloginfo( string $show = '' ): string {
+        return 'Test Store';
+    }
+}
+
+if ( ! class_exists( 'WC_Payment_Gateway', false ) ) {
+    class WC_Payment_Gateway {
+        public string $id = '';
+        public string $method_title = '';
+        public string $method_description = '';
+        public string $icon = '';
+        public string $title = '';
+        public string $description = '';
+        public string $enabled = '';
+        public bool $has_fields = false;
+        public array $supports = [];
+        public array $form_fields = [];
+        protected array $settings = [];
+
+        public function init_settings(): void {}
+
+        public function get_option( string $key, mixed $default = '' ): mixed {
+            return $this->settings[ $key ] ?? $default;
+        }
+
+        public function get_return_url( mixed $order = null ): string {
+            return 'https://store.example/thank-you';
+        }
+
+        public function is_available(): bool {
+            return true;
+        }
+
+        public function process_admin_options(): void {}
+    }
+}
+
+class Test_WC_Product {
+    public function __construct( private string $sku, private int $id ) {}
+
+    public function get_sku(): string {
+        return $this->sku;
+    }
+
+    public function get_id(): int {
+        return $this->id;
+    }
+}
+
+class Test_WC_Item {
+    public function __construct(
+        private string $name,
+        private int $qty,
+        private float $unit_total,
+        private ?Test_WC_Product $product
+    ) {}
+
+    public function get_product(): ?Test_WC_Product {
+        return $this->product;
+    }
+
+    public function get_name(): string {
+        return $this->name;
+    }
+
+    public function get_quantity(): int {
+        return $this->qty;
+    }
+
+    public function get_product_id(): int {
+        return $this->product?->get_id() ?? 0;
+    }
+
+    public function unit_total(): float {
+        return $this->unit_total;
+    }
+}
+
+class Test_WC_Fee {
+    public function __construct( private string $name, private float $total, private float $tax ) {}
+
+    public function get_name(): string {
+        return $this->name;
+    }
+
+    public function get_total(): float {
+        return $this->total;
+    }
+
+    public function get_total_tax(): float {
+        return $this->tax;
+    }
+}
+
+if ( ! class_exists( 'WC_Order', false ) ) {
+    class WC_Order {
+        private array $meta = [];
+
+        public function __construct(
+            private int $id,
+            private int $total,
+            private array $items = [],
+            private array $fees = [],
+            private int $shipping = 0,
+            private int $shipping_tax = 0
+        ) {}
+
+        public function get_id(): int {
+            return $this->id;
+        }
+
+        public function get_total(): int {
+            return $this->total;
+        }
+
+        public function get_items(): array {
+            return $this->items;
+        }
+
+        public function get_fees(): array {
+            return $this->fees;
+        }
+
+        public function get_shipping_total(): int {
+            return $this->shipping;
+        }
+
+        public function get_shipping_tax(): int {
+            return $this->shipping_tax;
+        }
+
+        public function get_item_total( mixed $item, bool $inc_tax = false ): float {
+            return $item->unit_total();
+        }
+
+        public function get_billing_first_name(): string {
+            return 'Test';
+        }
+
+        public function get_billing_last_name(): string {
+            return 'Buyer';
+        }
+
+        public function get_billing_email(): string {
+            return 'buyer@example.com';
+        }
+
+        public function get_meta( string $key ): mixed {
+            return $this->meta[ $key ] ?? '';
+        }
+
+        public function update_meta_data( string $key, mixed $value ): void {
+            $this->meta[ $key ] = $value;
+        }
+
+        public function save(): void {}
+
+        public function is_paid(): bool {
+            return false;
+        }
+    }
+}
+
+require_once __DIR__ . '/../includes/class-wc-gateway-oen.php';
+require_once __DIR__ . '/../includes/class-wc-gateway-oen-credit.php';
+require_once __DIR__ . '/../includes/class-wc-gateway-oen-cvs.php';
+
+class Exposed_OEN_CVS extends WC_Gateway_OEN_CVS {
+    public function product_details( WC_Order $order ): array {
+        return $this->build_product_details( $order );
+    }
+
+    public function checkout_params( WC_Order $order ): array {
+        return $this->build_checkout_params( $order );
+    }
+}
+
+class Exposed_OEN_Credit extends WC_Gateway_OEN_Credit {
+    public function checkout_params( WC_Order $order ): array {
+        return $this->build_checkout_params( $order );
+    }
+}
+
+function cp_sum( array $details ): int {
+    $sum = 0;
+    foreach ( $details as $line ) {
+        $sum += (int) $line['unitPrice'] * (int) $line['quantity'];
+    }
+    return $sum;
+}
+
+function test_product_details_single_line_when_itemization_off(): void {
+    $GLOBALS['test_options'] = [ 'oen_display_item_name' => 'no' ];
+
+    $details = ( new Exposed_OEN_CVS() )->product_details( new WC_Order( 1, 1000 ) );
+
+    test_assert( 1 === count( $details ), 'Itemization off should produce a single ORDER line.' );
+    test_assert( 'ORDER' === $details[0]['productionCode'], 'The single line should use the ORDER production code.' );
+    test_assert( 1000 === cp_sum( $details ), 'The single ORDER line unitPrice must equal the order total.' );
+}
+
+function test_product_details_adds_adjustment_line_to_reconcile_amount(): void {
+    // total 1000; item qty 3 @ rounded unit 333 = 999; an ADJ +1 line must reconcile to 1000.
+    $GLOBALS['test_options'] = [ 'oen_display_item_name' => 'yes' ];
+
+    $item    = new Test_WC_Item( 'Widget', 3, 333.0, new Test_WC_Product( 'SKU-1', 42 ) );
+    $details = ( new Exposed_OEN_CVS() )->product_details( new WC_Order( 2, 1000, [ $item ] ) );
+    $codes   = array_column( $details, 'productionCode' );
+
+    test_assert( 1000 === cp_sum( $details ), 'sum(unitPrice*quantity) must equal the order total (ADJ reconciliation prevents V0001).' );
+    test_assert( in_array( 'ADJ', $codes, true ), 'An ADJ line should be added when the itemized sum != order total.' );
+    test_assert( in_array( 'SKU-1', $codes, true ), 'An item production code should use the product SKU when present.' );
+}
+
+function test_product_details_includes_fees_and_shipping_and_reconciles(): void {
+    // item 2x200=400, fee 50+5tax=55, shipping 100 -> 555 total, diff 0 (no ADJ needed).
+    $GLOBALS['test_options'] = [ 'oen_display_item_name' => 'yes' ];
+
+    $item    = new Test_WC_Item( 'Thing', 2, 200.0, new Test_WC_Product( '', 7 ) );
+    $fee     = new Test_WC_Fee( 'Surcharge', 50.0, 5.0 );
+    $details = ( new Exposed_OEN_CVS() )->product_details( new WC_Order( 3, 555, [ $item ], [ $fee ], 100, 0 ) );
+    $codes   = array_column( $details, 'productionCode' );
+
+    test_assert( in_array( 'FEE', $codes, true ), 'Fees should appear as a FEE line.' );
+    test_assert( in_array( 'SHIPPING', $codes, true ), 'Shipping should appear as a SHIPPING line.' );
+    test_assert( in_array( '7', $codes, true ), 'An empty SKU should fall back to the product id.' );
+    test_assert( 555 === cp_sum( $details ), 'Itemized sum with fees + shipping must reconcile to the order total.' );
+}
+
+function test_cvs_gateway_restricts_allowed_payment_methods_to_cvs(): void {
+    $GLOBALS['test_options'] = [ 'oen_display_item_name' => 'no' ];
+
+    $params = ( new Exposed_OEN_CVS() )->checkout_params( new WC_Order( 4, 1000 ) );
+
+    test_assert(
+        [ 'cvs' ] === ( $params['allowedPaymentMethods'] ?? null ),
+        'The CVS gateway must send allowedPaymentMethods=[cvs] (exact backend enum string).'
+    );
+}
+
+function test_credit_gateway_omits_allowed_payment_methods(): void {
+    $GLOBALS['test_options'] = [ 'oen_display_item_name' => 'no' ];
+
+    $params = ( new Exposed_OEN_Credit() )->checkout_params( new WC_Order( 5, 1000 ) );
+
+    test_assert(
+        ! array_key_exists( 'allowedPaymentMethods', $params ),
+        'The Credit gateway should omit allowedPaymentMethods (card is the backend default; sending "card" is redundant).'
+    );
+}
+
+test_product_details_single_line_when_itemization_off();
+test_product_details_adds_adjustment_line_to_reconcile_amount();
+test_product_details_includes_fees_and_shipping_and_reconciles();
+test_cvs_gateway_restricts_allowed_payment_methods_to_cvs();
+test_credit_gateway_omits_allowed_payment_methods();
+
+echo "Checkout params harness passed.\n";

--- a/tests/WebhookParserTest.php
+++ b/tests/WebhookParserTest.php
@@ -313,6 +313,29 @@ function test_handler_requires_amount_for_verified_session_binding(): void {
     );
 }
 
+function test_parser_accepts_any_valid_v1_during_secret_rotation(): void {
+    // During a secret rotation the backend signs with both the current and the
+    // previous secret, sending multiple v1= values. The parser must accept the
+    // event if ANY v1 matches — here an unrelated v1 precedes the valid one.
+    $secret    = 'whsec_current_secret';
+    $timestamp = (string) time();
+    $raw_body  = wp_json_encode( [
+        'id'   => 'evt_rotation',
+        'type' => 'checkout_session.completed',
+        'data' => [ 'id' => 'sess_rot', 'orderId' => 'wc_rot' ],
+    ] );
+
+    $valid  = hash_hmac( 'sha256', $timestamp . '.' . $raw_body, $secret );
+    $header = 't=' . $timestamp . ',v1=00000000deadbeef,v1=' . $valid;
+
+    $payload = ( new OEN_Webhook_Parser( $secret ) )->parse( $raw_body, $header );
+
+    test_assert(
+        ( $payload['type'] ?? null ) === 'checkout_session.completed',
+        'Parser should accept the event when any v1 signature matches (secret-rotation grace).'
+    );
+}
+
 test_parser_verifies_signature_and_returns_event_type_and_nested_event_data();
 test_parser_rejects_invalid_signature();
 test_parser_rejects_stale_signature_timestamp();
@@ -323,5 +346,6 @@ test_handler_rejects_session_only_attempt_without_stored_session_or_matching_tra
 test_handler_maps_hosted_checkout_event_names_and_statuses();
 test_handler_accepts_top_level_completed_session_status();
 test_handler_requires_amount_for_verified_session_binding();
+test_parser_accepts_any_valid_v1_during_secret_rotation();
 
 echo "Webhook parser smoke harness passed.\n";

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,48 @@
+# L3 — Real dev/qa E2E (Hosted Checkout)
+
+Verifies the plugin against the **real** OEN Hosted Checkout backend once, to
+calibrate the L1/L2 stubs against reality. L1 (`tests/run-unit.sh`) and L2
+(`tests/runtime/run-webhook-runtime-test.sh`) run with no backend; this is the
+only layer that touches the live API.
+
+## Why this is gated
+- **Hosted Checkout is live only on `development` and `qa`, not production.**
+  `api.oen.tw/api/hosted-checkout/*` 404s today. Use `api.development.oen.tw/api`
+  (default) or `api.qa.oen.tw/api`.
+- **No self-serve `sk_` issuance.** You need a `sk_test_...` key for a domain whose
+  `paymentServiceStatus = ACTIVATE`, handed over out-of-band.
+- **The backend cannot reach `localhost`.** The webhook must be registered at a public
+  tunnel URL, so `checkout_session.completed` can come back.
+
+## Prereqs
+1. `sk_test_...` + `merchant_id` for a Hosted-Checkout-enabled dev/qa domain (ACTIVATE).
+2. Bench installed once: in `wordpress-payment-plugin/` run `docker compose up -d && ./setup.sh`.
+3. `docker-compose.override.yml` present in the bench (mount → worktree, sets `OEN_API_BASE_URL`). Restart the bench after adding it: `docker compose down && docker compose up -d`.
+4. A tunnel: `cloudflared tunnel --url http://localhost:8080` (note the printed `https://…` URL).
+
+## Run
+```sh
+# from this worktree:
+OEN_MERCHANT_ID=<merchant> \
+OEN_SK=sk_test_xxx \
+TUNNEL_URL=https://<sub>.trycloudflare.com \
+OEN_API_BASE_URL=https://api.development.oen.tw/api \
+  sh tests/e2e/configure-dev-bench.sh
+```
+Then place an order at http://localhost:8080 with **OEN Credit** or **OEN CVS**,
+complete payment on the real hosted checkout page, and let the webhook come back.
+
+## Evidence to capture (per the "keep evidence for all tests" rule)
+Store under `tests/evidence/<YYYYMMDD-HHMM>-t11-L3-dev/`:
+- **Screenshots**: classic checkout + **block checkout** (proves the Blocks port shows
+  OEN as selectable), the redirect to the real hosted checkout page, WP admin order screen.
+- **Recording**: the checkout → pay → return flow (screen recording or Playwright video).
+- **Payloads**: the real `checkout_session.completed` body + `OenPay-Signature` header
+  (from `wp-content/debug.log`, source `oen-payment*`), and the create/GET session responses.
+- **Order state**: `wp eval-file .../tests/e2e/inspect-order-by-id.php <order_id>` before/after.
+
+## What L3 confirms that stubs cannot
+Real signature passes against a real `whsec_`; the real GET-session shape (top-level
+status, top-level `paymentInfo` for CVS) matches what the plugin reads; the real
+`amount == Σ productDetails` reconciliation is accepted (no `V0001`); the Blocks
+methods actually render + redirect in a real WooCommerce block checkout.

--- a/tests/e2e/configure-dev-bench.sh
+++ b/tests/e2e/configure-dev-bench.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env sh
+set -eu
+# L3 E2E: configure the WordPress bench against the REAL dev/qa Hosted Checkout API,
+# and register a webhook at the PUBLIC tunnel URL (the backend cannot reach localhost).
+#
+# Prereqs:
+#   - Bench installed once:  (in wordpress-payment-plugin)  docker compose up -d && ./setup.sh
+#   - docker-compose.override.yml present (points the plugin mount at the worktree and
+#     sets OEN_API_BASE_URL). See tests/e2e/README.md.
+#   - A tunnel to the bench:  cloudflared tunnel --url http://localhost:8080
+#
+# Required env:
+#   OEN_MERCHANT_ID  merchant id of a Hosted-Checkout-enabled domain
+#   OEN_SK           sk_test_...  (the domain must be paymentServiceStatus=ACTIVATE)
+#   TUNNEL_URL       https URL printed by cloudflared (e.g. https://foo.trycloudflare.com)
+# Optional:
+#   OEN_API_BASE_URL default https://api.development.oen.tw/api  (or https://api.qa.oen.tw/api)
+#   BENCH_DIR        default /Users/rex1/work/Projects/wordpress-payment-plugin
+
+: "${OEN_MERCHANT_ID:?set OEN_MERCHANT_ID}"
+: "${OEN_SK:?set OEN_SK (sk_test_...)}"
+: "${TUNNEL_URL:?set TUNNEL_URL (cloudflared public URL)}"
+OEN_API_BASE_URL="${OEN_API_BASE_URL:-https://api.development.oen.tw/api}"
+BENCH_DIR="${BENCH_DIR:-/Users/rex1/work/Projects/wordpress-payment-plugin}"
+export OEN_API_BASE_URL
+
+WEBHOOK_URL="${TUNNEL_URL%/}/?wc-api=oen_payment"
+
+cd "$BENCH_DIR"
+wpcli() { docker compose run --rm wpcli wp --allow-root "$@"; }
+
+echo "== bring bench up (mount=worktree, OEN_API_BASE_URL=$OEN_API_BASE_URL) =="
+docker compose up -d db wordpress >/dev/null
+wpcli plugin activate woocommerce woocommerce-oen-payment >/dev/null 2>&1 || true
+
+echo "== set OEN options =="
+wpcli option update oen_enabled yes >/dev/null
+wpcli option update oen_merchant_id "$OEN_MERCHANT_ID" >/dev/null
+wpcli option update oen_api_token "$OEN_SK" >/dev/null
+wpcli option update oen_sandbox yes >/dev/null
+
+echo "== register webhook -> $WEBHOOK_URL =="
+wpcli eval-file "wp-content/plugins/woocommerce-oen-payment/tests/e2e/register-webhook.php" "$WEBHOOK_URL"
+
+cat <<EOF
+
+Configured. Next (capture evidence at each step):
+  1. Open http://localhost:8080 and place an order using "OEN Credit" or "OEN CVS".
+     - Screenshot: checkout page (classic AND block checkout), the redirect to the
+       real hosted checkout page (proves a real session was created on $OEN_API_BASE_URL).
+  2. Complete payment on the hosted checkout page (test card / CVS code).
+  3. The backend delivers checkout_session.completed -> $WEBHOOK_URL -> the order
+     should transition to processing/completed.
+  4. Verify + capture:
+       docker compose run --rm wpcli wp --allow-root eval-file \\
+         wp-content/plugins/woocommerce-oen-payment/tests/e2e/inspect-order-by-id.php <order_id>
+     - Screenshot: WP admin order screen; grab wp-content/debug.log webhook lines.
+EOF

--- a/tests/e2e/inspect-order-by-id.php
+++ b/tests/e2e/inspect-order-by-id.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Dump the OEN-relevant state of a WooCommerce order for L3 evidence capture.
+ *
+ *   wp eval-file wp-content/plugins/woocommerce-oen-payment/tests/e2e/inspect-order-by-id.php <order_id>
+ */
+
+$order_id = (int) ( $args[0] ?? 0 );
+$order    = $order_id > 0 ? wc_get_order( $order_id ) : null;
+
+if ( ! $order instanceof WC_Order ) {
+    fwrite( STDERR, "order not found: {$order_id}\n" );
+    exit( 1 );
+}
+
+echo wp_json_encode( [
+    'order_id'             => $order->get_id(),
+    'status'               => $order->get_status(),
+    'is_paid'              => $order->is_paid(),
+    'total'                => $order->get_total(),
+    'oen_order_id'         => (string) $order->get_meta( '_oen_order_id' ),
+    'oen_session_id'       => (string) $order->get_meta( '_oen_session_id' ),
+    'oen_checkout_url'     => (string) $order->get_meta( '_oen_checkout_url' ),
+    'oen_transaction_hid'  => (string) $order->get_meta( '_oen_transaction_hid' ),
+    'oen_transaction_id'   => (string) $order->get_meta( '_oen_transaction_id' ),
+    'oen_paid_at'          => (string) $order->get_meta( '_oen_paid_at' ),
+    'oen_cvs_name'         => (string) $order->get_meta( '_oen_cvs_name' ),
+    'oen_cvs_code'         => (string) $order->get_meta( '_oen_cvs_code' ),
+    'oen_cvs_expired_at'   => (string) $order->get_meta( '_oen_cvs_expired_at' ),
+], JSON_PRETTY_PRINT ) . "\n";

--- a/tests/e2e/probe-create-session.php
+++ b/tests/e2e/probe-create-session.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Probe the plugin's OWN api-client create_session against the configured backend.
+ *
+ * With an invalid key this verifies — end to end, through the plugin — that:
+ *   - from_settings() reads the configured merchant/secret + OEN_API_BASE_URL,
+ *   - the request reaches the real /api/hosted-checkout/v1/sessions route,
+ *   - parse_response() correctly decodes the real `{error:{code,message}}` envelope.
+ * Expect a thrown RuntimeException carrying [AUTH_INVALID_KEY] (HTTP 401) on dev/qa.
+ *
+ *   wp eval-file wp-content/plugins/woocommerce-oen-payment/tests/e2e/probe-create-session.php
+ */
+
+try {
+    $client = OEN_API_Client::from_settings();
+    $result = $client->create_session( [
+        'amount'         => 100,
+        'currency'       => 'TWD',
+        'orderId'        => 'probe-' . time(),
+        'productDetails' => [
+            [ 'productionCode' => 'P', 'description' => 'probe', 'quantity' => 1, 'unit' => 'set', 'unitPrice' => 100 ],
+        ],
+    ] );
+    echo wp_json_encode( [ 'result' => 'UNEXPECTED_SUCCESS', 'session' => $result ] ) . "\n";
+} catch ( \Throwable $e ) {
+    echo wp_json_encode( [
+        'result'       => 'threw_as_expected',
+        'message'      => $e->getMessage(),
+        'base_url_env' => getenv( 'OEN_API_BASE_URL' ) ?: '(unset)',
+    ] ) . "\n";
+}

--- a/tests/e2e/probe-get-session.php
+++ b/tests/e2e/probe-get-session.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * GET a Hosted Checkout session through the plugin's api-client, to verify the
+ * plugin reads the REAL session shape (top-level status/amount/orderId/etc.) that
+ * the webhook handler's verify_session() relies on.
+ *
+ *   wp eval-file .../tests/e2e/probe-get-session.php <session_id>
+ */
+
+$session_id = $args[0] ?? '';
+
+try {
+    $client  = OEN_API_Client::from_settings();
+    $session = $client->get_session( $session_id );
+    echo wp_json_encode( [ 'ok' => true, 'session' => $session ], JSON_PRETTY_PRINT ) . "\n";
+} catch ( \Throwable $e ) {
+    echo wp_json_encode( [ 'ok' => false, 'error' => $e->getMessage() ] ) . "\n";
+}

--- a/tests/e2e/probe-process-payment.php
+++ b/tests/e2e/probe-process-payment.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Create a real WooCommerce order and run the OEN gateway's process_payment()
+ * against the configured (real dev) Hosted Checkout backend — proving the
+ * plugin's create side end-to-end through actual plugin code (build_checkout_params
+ * from a real order → create_session → meta storage → redirect result).
+ *
+ *   wp eval-file .../tests/e2e/probe-process-payment.php <product_id>
+ */
+
+$product_id = (int) ( $args[0] ?? 0 );
+
+$order = wc_create_order();
+$order->set_status( 'pending' );
+$order->set_currency( 'TWD' );
+if ( $product_id > 0 ) {
+    $product = wc_get_product( $product_id );
+    if ( $product ) {
+        $order->add_product( $product, 1 );
+    }
+}
+$order->set_billing_first_name( 'Test' );
+$order->set_billing_last_name( 'Buyer' );
+$order->set_billing_email( 'buyer@example.com' );
+$order->calculate_totals();
+$order->save();
+
+try {
+    $gateway = new WC_Gateway_OEN_Credit();
+    $result  = $gateway->process_payment( $order->get_id() );
+    $order   = wc_get_order( $order->get_id() );
+
+    echo wp_json_encode( [
+        'order_id'         => $order->get_id(),
+        'total'            => $order->get_total(),
+        'result'           => $result['result'] ?? null,
+        'redirect'         => $result['redirect'] ?? null,
+        'oen_order_id'     => (string) $order->get_meta( '_oen_order_id' ),
+        'oen_session_id'   => (string) $order->get_meta( '_oen_session_id' ),
+        'oen_checkout_url' => (string) $order->get_meta( '_oen_checkout_url' ),
+        'status'           => $order->get_status(),
+    ], JSON_PRETTY_PRINT ) . "\n";
+} catch ( \Throwable $e ) {
+    echo wp_json_encode( [ 'error' => $e->getMessage() ] ) . "\n";
+}

--- a/tests/e2e/register-webhook.php
+++ b/tests/e2e/register-webhook.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Register a Hosted Checkout webhook that points at the PUBLIC tunnel URL, and
+ * store its signing secret — so the real backend can reach this local bench.
+ *
+ * The plugin's built-in auto-registration derives the URL from home_url() (i.e.
+ * http://localhost:8080), which the backend cannot reach; this helper registers
+ * the tunnel URL instead.
+ *
+ * Run inside the bench:
+ *   wp eval-file wp-content/plugins/woocommerce-oen-payment/tests/e2e/register-webhook.php "<tunnel>/?wc-api=oen_payment"
+ */
+
+$url = $args[0] ?? '';
+
+if ( '' === $url ) {
+    fwrite( STDERR, "usage: register-webhook.php <public_webhook_url>\n" );
+    exit( 1 );
+}
+
+$events = [
+    'checkout_session.completed',
+    'checkout_session.failed',
+    'checkout_session.expired',
+    'checkout_session.cancelled',
+    'refund.created',
+    'refund.succeeded',
+];
+
+try {
+    $client   = OEN_API_Client::from_settings();
+    $resource = $client->create_webhook( $url, $events );
+} catch ( \Throwable $e ) {
+    fwrite( STDERR, 'webhook registration failed: ' . $e->getMessage() . "\n" );
+    exit( 1 );
+}
+
+$id     = (string) ( $resource['id'] ?? '' );
+$secret = (string) ( $resource['secret'] ?? '' );
+
+if ( '' === $id || '' === $secret ) {
+    fwrite( STDERR, "backend did not return webhook id + secret (secret is only returned on create/rotate)\n" );
+    exit( 1 );
+}
+
+update_option( 'oen_webhook_id', $id );
+update_option( 'oen_webhook_secret', $secret );
+
+echo wp_json_encode( [
+    'webhook_id'     => $id,
+    'secret_stored'  => true,
+    'url'            => $url,
+    'enabled_events' => $events,
+] ) . "\n";

--- a/tests/run-unit.sh
+++ b/tests/run-unit.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+# Run all L1 unit/contract harnesses (no Docker, no live backend).
+# Exits non-zero if any harness fails. POSIX sh for macOS/Linux/CI parity.
+set -u
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+FAIL=0
+
+for t in \
+    ApiClientTest \
+    WebhookParserTest \
+    WebhookHandlerIntegrationTest \
+    WebhookRegistrationTest \
+    CheckoutParamsTest \
+    BlocksPaymentMethodTest
+do
+    printf '\n===== %s =====\n' "$t"
+    if php "$DIR/$t.php"; then
+        :
+    else
+        printf '!!!!! %s FAILED !!!!!\n' "$t"
+        FAIL=1
+    fi
+done
+
+printf '\n'
+if [ "$FAIL" -eq 0 ]; then
+    printf 'ALL UNIT HARNESSES PASSED\n'
+else
+    printf 'ONE OR MORE UNIT HARNESSES FAILED\n'
+fi
+exit "$FAIL"

--- a/tests/runtime/api-stub-router.php
+++ b/tests/runtime/api-stub-router.php
@@ -2,90 +2,138 @@
 
 declare( strict_types=1 );
 
-$request_uri = $_SERVER['REQUEST_URI'] ?? '/';
-$path        = (string) parse_url( $request_uri, PHP_URL_PATH );
+/**
+ * Real Hosted Checkout API stub for the L2 runtime harness.
+ *
+ * Serves the SAME shapes as the merged backend (develop/qa), verified against
+ * source (OC-6900):
+ *   - 2xx success: the raw resource object — NO legacy `{ code: 'S0000', data }` wrapper.
+ *   - GET session: the lifecycle `status` at the TOP LEVEL
+ *     (created/completed/failed/expired/cancelled); there is NO nested
+ *     `transaction` object. CVS sessions carry a flat top-level `paymentInfo`.
+ *   - errors: `{ error: { code, message }, requestId }` with the matching HTTP status.
+ *
+ * This replaced an earlier stub that still encoded the old S0000 / nested
+ * `transaction.status` contract (a shape the backend never returns), which would
+ * validate the plugin against a fiction. Keep this stub in lock-step with the
+ * backend contract, not with the plugin's internal fallbacks.
+ */
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+$path   = (string) parse_url( $_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH );
 
 header( 'Content-Type: application/json' );
 
+$send = static function ( int $status, array $body ): void {
+    http_response_code( $status );
+    echo json_encode( $body );
+};
+
+$error = static function ( int $status, string $code, string $message ) use ( $send ): void {
+    $send(
+        $status,
+        [
+            'error'     => [ 'code' => $code, 'message' => $message ],
+            'requestId' => 'req_stub_' . bin2hex( random_bytes( 6 ) ),
+        ]
+    );
+};
+
 if ( '/health' === $path ) {
-    echo json_encode( [ 'status' => 'ok' ] );
+    $send( 200, [ 'status' => 'ok' ] );
     return;
 }
 
-if ( 1 === preg_match( '#^/hosted-checkout/v1/sessions/([^/]+)$#', $path, $matches ) ) {
+// Create session: POST /hosted-checkout/v1/sessions -> minimal raw resource (HTTP 200).
+if ( 'POST' === $method && '/hosted-checkout/v1/sessions' === $path ) {
+    $send(
+        200,
+        [
+            'id'          => 'cs_stub_' . bin2hex( random_bytes( 6 ) ),
+            'checkoutUrl' => 'http://api-stub:8080/checkout/stub',
+            'status'      => 'created',
+            'expiresAt'   => gmdate( 'c', time() + 1800 ),
+        ]
+    );
+    return;
+}
+
+// Get session: GET /hosted-checkout/v1/sessions/{id} -> raw resource, top-level status.
+if ( 'GET' === $method && 1 === preg_match( '#^/hosted-checkout/v1/sessions/([^/]+)$#', $path, $matches ) ) {
     $session_id = urldecode( $matches[1] );
 
-    $payload = match ( $session_id ) {
-        'sess_runtime_signed_ambiguous' => [
-            'code' => 'S0000',
-            'data' => [
-                'id'      => $session_id,
-                'orderId' => 'wc-runtime-signed-ambiguous',
-                'status'  => 'completed',
-                'amount'  => 1234,
-            ],
+    $sessions = [
+        // Completed + matching amount/order -> the order must be paid.
+        // transactionId/Hid are returned at the TOP LEVEL (no nested transaction).
+        'sess_runtime_signed_success'        => [
+            'id'             => 'sess_runtime_signed_success',
+            'status'         => 'completed',
+            'amount'         => 1234,
+            'currency'       => 'TWD',
+            'orderId'        => 'wc-runtime-signed-success',
+            'transactionId'  => 'txn_runtime_success_internal',
+            'transactionHid' => 'txn_runtime_success_001',
+            'expiresAt'      => gmdate( 'c', time() + 1800 ),
         ],
-        'sess_runtime_signed_success' => [
-            'code' => 'S0000',
-            'data' => [
-                'id'      => $session_id,
-                'orderId' => 'wc-runtime-signed-success',
-                'status'  => 'pending',
-                'amount'  => 1234,
-                'transaction' => [
-                    'status'         => 'charged',
-                    'transactionHid' => 'txn_runtime_success_001',
-                    'transactionId'  => 'txn_runtime_success_internal',
-                    'amount'         => 1234,
-                ],
-            ],
-        ],
-        'sess_runtime_signed_missing_amount' => [
-            'code' => 'S0000',
-            'data' => [
-                'id'          => $session_id,
-                'orderId'     => 'wc-runtime-signed-missing-amount',
-                'transaction' => [
-                    'status' => 'charged',
-                ],
-            ],
-        ],
-        'sess_runtime_cvs_pending' => [
-            'code' => 'S0000',
-            'data' => [
-                'id'      => $session_id,
-                'orderId' => 'wc-runtime-cvs-pending',
-                'status'  => 'completed',
-                'amount'  => 1234,
-                'transaction' => [
-                    'status'         => 'pending',
-                    'transactionHid' => 'txn_runtime_cvs_pending_001',
-                    'transactionId'  => 'txn_runtime_cvs_pending_internal',
-                    'amount'         => 1234,
-                    'paymentInfo'    => [
-                        'cvsName'    => 'FamilyMart',
-                        'code'       => 'CVS1234567890',
-                        'expiredAt'  => '2026-04-13T23:59:59+08:00',
-                    ],
-                ],
-            ],
-        ],
-        default => [
-            'code'    => 'E404',
-            'message' => 'Session not found',
-        ],
-    };
 
-    if ( 'S0000' !== ( $payload['code'] ?? '' ) ) {
-        http_response_code( 404 );
+        // Authoritative status is still pending -> a completed webhook must be
+        // IGNORED. The plugin trusts the GET-session status over the webhook claim.
+        'sess_runtime_signed_ambiguous'      => [
+            'id'       => 'sess_runtime_signed_ambiguous',
+            'status'   => 'pending',
+            'amount'   => 1234,
+            'currency' => 'TWD',
+            'orderId'  => 'wc-runtime-signed-ambiguous',
+        ],
+
+        // No amount field at all -> verification must fail closed (502).
+        'sess_runtime_signed_missing_amount' => [
+            'id'      => 'sess_runtime_signed_missing_amount',
+            'status'  => 'completed',
+            'orderId' => 'wc-runtime-signed-missing-amount',
+        ],
+
+        // CVS awaiting payment: paymentInfo present but session not yet completed
+        // -> the completed webhook is ignored and no CVS meta is stored.
+        'sess_runtime_cvs_pending'           => [
+            'id'          => 'sess_runtime_cvs_pending',
+            'status'      => 'pending',
+            'amount'      => 1234,
+            'currency'    => 'TWD',
+            'orderId'     => 'wc-runtime-cvs-pending',
+            'paymentInfo' => [
+                'method'    => 'cvs',
+                'code'      => 'CVS1234567890',
+                'cvsName'   => 'FamilyMart',
+                'expiredAt' => '2026-04-13T23:59:59+08:00',
+            ],
+        ],
+
+        // CVS paid: completed + top-level paymentInfo -> order paid AND CVS meta persisted.
+        'sess_runtime_cvs_completed'         => [
+            'id'             => 'sess_runtime_cvs_completed',
+            'status'         => 'completed',
+            'amount'         => 1234,
+            'currency'       => 'TWD',
+            'orderId'        => 'wc-runtime-cvs-completed',
+            'transactionId'  => 'txn_runtime_cvs_internal',
+            'transactionHid' => 'txn_runtime_cvs_001',
+            'paymentInfo'    => [
+                'method'    => 'cvs',
+                'code'      => 'CVS1234567890',
+                'cvsName'   => 'FamilyMart',
+                'expiredAt' => '2026-04-13T23:59:59+08:00',
+            ],
+        ],
+    ];
+
+    if ( isset( $sessions[ $session_id ] ) ) {
+        $send( 200, $sessions[ $session_id ] );
+        return;
     }
 
-    echo json_encode( $payload );
+    $error( 404, 'SESSION_NOT_FOUND', 'No such session' );
     return;
 }
 
-http_response_code( 404 );
-echo json_encode( [
-    'code'    => 'E404',
-    'message' => 'Not found',
-] );
+$error( 404, 'INVALID_REQUEST', 'Not found' );

--- a/tests/runtime/inspect-order.php
+++ b/tests/runtime/inspect-order.php
@@ -9,6 +9,7 @@ $fixtures = [
     'signed-missing-amount' => 'wc-runtime-signed-missing-amount',
     'invalid-signature' => 'wc-runtime-signed-ambiguous',
     'cvs-pending' => 'wc-runtime-cvs-pending',
+    'cvs-completed' => 'wc-runtime-cvs-completed',
 ];
 
 if ( ! isset( $fixtures[ $case ] ) ) {

--- a/tests/runtime/prepare-order.php
+++ b/tests/runtime/prepare-order.php
@@ -33,6 +33,11 @@ $fixtures = [
         'session_id'   => 'sess_runtime_cvs_pending',
         'total'        => 1234,
     ],
+    'cvs-completed' => [
+        'oen_order_id' => 'wc-runtime-cvs-completed',
+        'session_id'   => 'sess_runtime_cvs_completed',
+        'total'        => 1234,
+    ],
 ];
 
 if ( ! isset( $fixtures[ $case ] ) ) {

--- a/tests/runtime/run-webhook-runtime-test.sh
+++ b/tests/runtime/run-webhook-runtime-test.sh
@@ -382,8 +382,43 @@ run_cvs_pending_case() {
   rm -f "$response_file" "$order_file"
 }
 
+run_cvs_completed_case() {
+  local prep_json
+  local response_file
+  local order_file
+  local status_code
+  local payload
+  local signature
+
+  prep_json="$(prepare_order 'cvs-completed')"
+  payload="$(php -r '
+    $data = json_decode($argv[1], true);
+    echo json_encode([
+      "type" => "checkout_session.completed",
+      "data" => [
+        "id" => $data["session_id"],
+        "orderId" => $data["oen_order_id"],
+        "status" => "completed",
+      ],
+    ]);
+  ' "$prep_json")"
+  signature="$(build_signature "$payload" "$WEBHOOK_SECRET")"
+  response_file="$(mktemp)"
+  order_file="$(mktemp)"
+
+  status_code="$(post_webhook "$payload" "$signature" "$response_file")"
+  inspect_order 'cvs-completed' >"$order_file"
+
+  assert_equals "200" "$status_code" "cvs completed webhook should return 200"
+  assert_equals "true" "$(json_field "$order_file" "is_paid")" "cvs completed webhook should mark order paid"
+  assert_equals "CVS1234567890" "$(json_field "$order_file" "oen_cvs_code")" "cvs completed webhook should persist the CVS code from the top-level paymentInfo"
+
+  rm -f "$response_file" "$order_file"
+}
+
 bootstrap_wordpress
 run_cvs_pending_case
+run_cvs_completed_case
 run_signed_ambiguous_case
 run_signed_success_case
 run_signed_stale_case

--- a/woocommerce-oen-payment.php
+++ b/woocommerce-oen-payment.php
@@ -43,6 +43,11 @@ add_action( 'before_woocommerce_init', function (): void {
             __FILE__,
             true
         );
+        \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility(
+            'cart_checkout_blocks',
+            __FILE__,
+            true
+        );
     }
 } );
 
@@ -89,4 +94,20 @@ add_action( 'plugins_loaded', function (): void {
     new OEN_Webhook_Handler();
     new OEN_Email_Handler();
     new OEN_Error_Handler();
+} );
+
+add_action( 'woocommerce_blocks_loaded', function (): void {
+    if ( ! class_exists( '\Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) ) {
+        return;
+    }
+
+    require_once OEN_PAYMENT_PLUGIN_DIR . 'includes/class-oen-blocks-payment-method.php';
+
+    add_action(
+        'woocommerce_blocks_payment_method_type_registration',
+        function ( \Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $registry ): void {
+            $registry->register( new OEN_Blocks_Payment_Method( 'oen_credit', WC_Gateway_OEN_Credit::class ) );
+            $registry->register( new OEN_Blocks_Payment_Method( 'oen_cvs', WC_Gateway_OEN_CVS::class ) );
+        }
+    );
 } );


### PR DESCRIPTION
## Summary

- Adds WooCommerce **Cart & Checkout Blocks** support for the OEN gateway — registers **OEN Credit** (`oen_credit`) and **OEN CVS** (`oen_cvs`) as Blocks payment methods via `AbstractPaymentMethodType` + `registerPaymentMethod`, wired on `woocommerce_blocks_loaded`, with `cart_checkout_blocks` (+ HPOS) compatibility declared.
- Adds a **layered integration test suite** and realigns the runtime stub to the current Hosted Checkout API response shape (top-level `status`, flat `paymentInfo`, `{error}` envelope), replacing an outdated mismatched shape that could green-light incorrectly.
- Verified against a live backend environment, not just mocks.

## Architecture

```
Compatibility (before_woocommerce_init)
  FeaturesUtil::declare_compatibility('cart_checkout_blocks', ...)
  FeaturesUtil::declare_compatibility('custom_order_tables' /* HPOS */, ...)

Server (PHP)                                   Client (JS, block checkout)
────────────                                   ───────────────────────────
woocommerce_blocks_loaded (hook)               assets/js/blocks-payment-method.js
        │                                                │
        ▼                                                ▼
require class-oen-blocks-payment-method.php     registerPaymentMethod({ name:'oen_credit', … })
        │                                       registerPaymentMethod({ name:'oen_cvs',    … })
        ▼                                                │
woocommerce_blocks_payment_method_type_registration      │
        │                                                │
        ▼                                                │
registry->register(new OEN_Blocks_Payment_Method('oen_credit', WC_Gateway_OEN_Credit))
registry->register(new OEN_Blocks_Payment_Method('oen_cvs',    WC_Gateway_OEN_CVS))
        │                                                │
        ▼                                                ▼
OEN_Blocks_Payment_Method extends AbstractPaymentMethodType     Block Checkout renders
  • is_active()                → gates on parent gateway         OEN Credit / OEN CVS as
  • get_payment_method_script_handles() → enqueue the JS         selectable methods
  • get_payment_method_data()  → {title, description, supports}  (redirect gateway: on
        └──────────── Store API ─────────────►                   place-order → plugin
                                                                  creates session + redirects)
```

## Changes

### 新增
| 檔案 | 用途 |
|---|---|
| `includes/class-oen-blocks-payment-method.php` | Blocks payment-method type(`is_active` gate、script handles、method data) |
| `assets/js/blocks-payment-method.js` | Block checkout client registration |
| `tests/run-unit.sh` | L1 一鍵 runner |
| `tests/CheckoutParamsTest.php` | amount-ADJ 對帳 + `allowedPaymentMethods` |
| `tests/BlocksPaymentMethodTest.php` | Blocks `is_active` gate 測試 |
| `tests/e2e/*` | L3 live-environment probes + bench 設定 + webhook 註冊 |

### 修改
| 檔案 | 變更 |
|---|---|
| `woocommerce-oen-payment.php` | Blocks wiring + `FeaturesUtil` 相容宣告 |
| `tests/runtime/api-stub-router.php` | 對齊目前 API response shape;新增 cvs-completed |
| `tests/WebhookParserTest.php` | 多 `v1` secret rotation 測試 |
| `tests/runtime/{prepare,inspect}-order.php`, `run-webhook-runtime-test.sh` | cvs-completed case |
| `.gitignore` | 排除 `tests/evidence/`(測試產物留本地不進 repo) |

## Test Plan

- [x] **L1** 契約單元 6/6（`sh tests/run-unit.sh`）
- [x] **L2** dockerized runtime 7/7（對齊真 shape 的 stub）
- [x] **Blocks** 於真 block checkout 渲染 oen_credit / oen_cvs
- [x] **端點 / 錯誤 envelope** 對 live 環境驗證（auth 失敗回文件化的 `{error}` envelope）
- [x] **L3 真刷卡**（信用卡 + 3-D Secure）經 hosted checkout 頁完成付款
- [ ] **完整 webhook → order paid round-trip** — 待後端環境提供完成 webhook（內部追蹤）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
